### PR TITLE
Rename json ser to camel case

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -11,7 +11,7 @@ type StarknetDomain struct {
 
 // TradingFeeModel represents trading fees for a market
 type TradingFeeModel struct {
-	Market         string `json:"market"`
+	Market         string          `json:"market"`
 	MakerFeeRate   decimal.Decimal `json:"makerFeeRate"`
 	TakerFeeRate   decimal.Decimal `json:"takerFeeRate"`
 	BuilderFeeRate decimal.Decimal `json:"builderFeeRate"`

--- a/src/config.go
+++ b/src/config.go
@@ -3,18 +3,18 @@ package sdk
 import "github.com/shopspring/decimal"
 
 type StarknetDomain struct {
-	Name     string `json:"name"`
-	Version  string `json:"version"`
-	ChainID  string `json:"chain_id"`
-	Revision string `json:"revision"`
+	Name     string
+	Version  string
+	ChainID  string
+	Revision string
 }
 
 // TradingFeeModel represents trading fees for a market
 type TradingFeeModel struct {
-	Market         string          `json:"market"`
-	MakerFeeRate   decimal.Decimal `json:"maker_fee_rate"`
-	TakerFeeRate   decimal.Decimal `json:"taker_fee_rate"`
-	BuilderFeeRate decimal.Decimal `json:"builder_fee_rate"`
+	Market         string
+	MakerFeeRate   decimal.Decimal
+	TakerFeeRate   decimal.Decimal
+	BuilderFeeRate decimal.Decimal
 }
 
 var DefaultFees = TradingFeeModel{

--- a/src/config.go
+++ b/src/config.go
@@ -11,10 +11,10 @@ type StarknetDomain struct {
 
 // TradingFeeModel represents trading fees for a market
 type TradingFeeModel struct {
-	Market         string
-	MakerFeeRate   decimal.Decimal
-	TakerFeeRate   decimal.Decimal
-	BuilderFeeRate decimal.Decimal
+	Market         string `json:"market"`
+	MakerFeeRate   decimal.Decimal `json:"makerFeeRate"`
+	TakerFeeRate   decimal.Decimal `json:"takerFeeRate"`
+	BuilderFeeRate decimal.Decimal `json:"builderFeeRate"`
 }
 
 var DefaultFees = TradingFeeModel{

--- a/src/markets.go
+++ b/src/markets.go
@@ -2,18 +2,18 @@ package sdk
 
 type L2ConfigModel struct {
 	Type                 string `json:"type"`
-	CollateralID         string `json:"collateral_id"`
-	CollateralResolution int64  `json:"collateral_resolution"`
-	SyntheticID          string `json:"synthetic_id"`
-	SyntheticResolution  int64  `json:"synthetic_resolution"`
+	CollateralID         string `json:"collateralId"`
+	CollateralResolution int64  `json:"collateralResolution"`
+	SyntheticID          string `json:"syntheticId"`
+	SyntheticResolution  int64  `json:"syntheticResolution"`
 }
 
 type MarketModel struct {
 	Name                     string        `json:"name"`
-	AssetName                string        `json:"asset_name"`
-	AssetPrecision           int           `json:"asset_precision"`
-	CollateralAssetName      string        `json:"collateral_asset_name"`
-	CollateralAssetPrecision int           `json:"collateral_asset_precision"`
+	AssetName                string        `json:"assetName"`
+	AssetPrecision           int           `json:"assetPrecision"`
+	CollateralAssetName      string        `json:"collateralAssetName"`
+	CollateralAssetPrecision int           `json:"collateralAssetPrecision"`
 	Active                   bool          `json:"active"`
-	L2Config                 L2ConfigModel `json:"l2_config"`
+	L2Config                 L2ConfigModel `json:"l2Config"`
 }


### PR DESCRIPTION
I have removed the JSON annotations in `StarknetDomain`, as this seems to be hardcoded in the SDK rather than directly fetched from the API (and therefore does not need to be (de)serialised). I have updated the `TradingFeeModel`, `MarketModel` and `L2ConfigModel` to be serialised in JSON with camel case keys.